### PR TITLE
 加入禁止非登录用户(游客或非授权)发起远的程控制

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,3 +338,4 @@ docker run --rm --entrypoint /usr/bin/rustdesk-utils  wy368/openrustdesk-server:
 | RUST_LOG | 所有 | 设置调试级别（error\|warn\|info\|debug\|trace） |
 | SINGLE_BANDWIDTH | hbbr | 单个连接的最大带宽（Mb/s） |
 | TOTAL_BANDWIDTH | hbbr | 总最大带宽（Mb/s） |
+| LOGGED_IN_ONLY | hbbs | 如果设置为 **"YES"**，则禁止尚未登录用户发起的远控请求 |

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ docker run --rm --entrypoint /usr/bin/rustdesk-utils  wy368/openrustdesk-server:
 | 变量名 | 适用二进制文件 | 描述 |
 | --- | --- | --- |
 | ALWAYS_USE_RELAY | hbbs | 如果设置为 **"Y"**，则禁止直接对等连接 |
-| LOGGED_IN_ONLY | hbbs | 如果设置为 **"YES"**，则禁止尚未登录用户发起的远控请求 |
+| LOGGED_IN_ONLY | hbbs | 如果设置为 **"Y"**，则禁止尚未登录用户发起的远控请求 |
 | DB_URL | hbbs | 数据库文件路径 |
 | DOWNGRADE_START_CHECK | hbbr | 下降检查延迟（秒） |
 | DOWNGRADE_THRESHOLD | hbbr | 下降检查阈值（bit/ms） |

--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ docker run --rm --entrypoint /usr/bin/rustdesk-utils  wy368/openrustdesk-server:
 | 变量名 | 适用二进制文件 | 描述 |
 | --- | --- | --- |
 | ALWAYS_USE_RELAY | hbbs | 如果设置为 **"Y"**，则禁止直接对等连接 |
+| LOGGED_IN_ONLY | hbbs | 如果设置为 **"YES"**，则禁止尚未登录用户发起的远控请求 |
 | DB_URL | hbbs | 数据库文件路径 |
 | DOWNGRADE_START_CHECK | hbbr | 下降检查延迟（秒） |
 | DOWNGRADE_THRESHOLD | hbbr | 下降检查阈值（bit/ms） |
@@ -338,4 +339,4 @@ docker run --rm --entrypoint /usr/bin/rustdesk-utils  wy368/openrustdesk-server:
 | RUST_LOG | 所有 | 设置调试级别（error\|warn\|info\|debug\|trace） |
 | SINGLE_BANDWIDTH | hbbr | 单个连接的最大带宽（Mb/s） |
 | TOTAL_BANDWIDTH | hbbr | 总最大带宽（Mb/s） |
-| LOGGED_IN_ONLY | hbbs | 如果设置为 **"YES"**，则禁止尚未登录用户发起的远控请求 |
+

--- a/src/rendezvous_server.rs
+++ b/src/rendezvous_server.rs
@@ -823,7 +823,7 @@ impl RendezvousServer {
         {
             let mut msg_out = RendezvousMessage::new();
             msg_out.set_punch_hole_response(PunchHoleResponse {
-                other_failure: String::from("The connection is not allowed. You have not logged in."),
+                other_failure: String::from("拒绝访问，您尚未登录，请联系管理员！"),
                 ..Default::default()
             });
             return Ok((msg_out, None));

--- a/src/rendezvous_server.rs
+++ b/src/rendezvous_server.rs
@@ -813,9 +813,6 @@ impl RendezvousServer {
             });
             return Ok((msg_out, None));
         }
-
-
-
             if ph.token.is_empty() && std::env::var("LOGGED_IN_ONLY")
             .unwrap_or_default()
             .to_uppercase()

--- a/src/rendezvous_server.rs
+++ b/src/rendezvous_server.rs
@@ -813,6 +813,22 @@ impl RendezvousServer {
             });
             return Ok((msg_out, None));
         }
+
+
+
+            if ph.token.is_empty() && std::env::var("LOGGED_IN_ONLY")
+            .unwrap_or_default()
+            .to_uppercase()
+            == "Y"
+        {
+            let mut msg_out = RendezvousMessage::new();
+            msg_out.set_punch_hole_response(PunchHoleResponse {
+                other_failure: String::from("The connection is not allowed. You have not logged in."),
+                ..Default::default()
+            });
+            return Ok((msg_out, None));
+        }
+        
         let id = ph.id;
         // punch hole request from A, relay to B,
         // check if in same intranet first,


### PR DESCRIPTION
* 加入禁止非登录用户(游客或非授权)发起远的程控制
这功能是可选性的，方便第三方API对于管理的需要

 <img src="https://github.com/user-attachments/assets/b6fcb3e1-7466-43ed-86a9-c54bce6517b0" width="100" height="100">

<img src="https://github.com/user-attachments/assets/0a3e1174-b6e2-41e3-bd67-a53675bc96d6" width="800" height="400">